### PR TITLE
Update to Factorio 0.12.11+.

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {
   "name": "nixie-tubes",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "title": "Nixie Tubes",
   "author": "GopherAtl",
   "homepage": "http://google.com",
   "contact": "gopheratl@gmail.com",
   "description": "Adds nixie tubes, for displaying values from a connected circuit network.",
-  "dependencies": ["base >= 0.12.0"]
+  "dependencies": ["base >= 0.12.11"]
 }


### PR DESCRIPTION
Notable changes:
- `on_save` is no longer a valid event; luckily, it wasn't doing anything necessary (`onLoad`'s assignment `nixie_map = global.nixie_tubes.nixies` ensures that changes to `nixie_map` propagate to the global table.
- `on_load` wasn't doing anything with `mod_version` and `mod_data_version` -- I've added a couple of stub functions to be used to trigger migrations or whatever, based on the values loaded versus values saved. In truth, this should probably be handled using the new `on_configuration_changed` event, and possibly regular migration scripts, but I was going for minimal changes here.
- `on_tick` was being set twice (!?), trimmed that back to normal.
